### PR TITLE
Create Docker containers for Nexus and Reprepro

### DIFF
--- a/boot2docker/Vagrantfile
+++ b/boot2docker/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.require_version ">= 1.6.3"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  
+  config.vm.define "boot2docker"
+  
+  config.vm.box = "yungsang/boot2docker"
+  config.vm.box_url = "https://vagrantcloud.com/yungsang/boxes/boot2docker/versions/26/providers/virtualbox.box"
+  
+  config.vm.synced_folder "../", "/home/docker/pipeline-it"
+  
+  config.vm.network :private_network, ip: "192.168.10.12"
+  config.vm.network :forwarded_port, guest: 8081, host: 8081
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+  
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+  
+end

--- a/nexus/Dockerfile
+++ b/nexus/Dockerfile
@@ -1,0 +1,7 @@
+FROM        ubuntu:trusty
+RUN         apt-get update
+RUN         apt-get install -y curl openjdk-7-jre
+RUN         mkdir -p /srv/nexus
+RUN         curl -sS http://download.sonatype.com/nexus/oss/nexus-2.5-bundle.tar.gz | tar -xzf- -C /srv/nexus/
+EXPOSE      8081
+ENTRYPOINT  ["/bin/bash", "-c", "RUN_AS_USER=root /srv/nexus/nexus-2.5.0-04/bin/nexus start && tail -f /srv/nexus/nexus-2.5.0-04/logs/wrapper.log"]

--- a/nexus/README.md
+++ b/nexus/README.md
@@ -1,0 +1,57 @@
+# Nexus Maven Repository
+
+## Running the service
+
+    docker build -t daisy/nexus .
+    docker run -d -p 8081:8081 --name nexus daisy/nexus
+
+If docker is not available, use the boot2docker image:
+
+    cd ../boot2docker
+    vagrant up
+    vagrant ssh
+
+    $ docker build -t daisy/nexus ~/pipeline-it/nexus
+    $ docker run -d -p 8081:8081 --name nexus daisy/nexus
+
+# Using the service
+
+For deploying to the repository, add the following to your `distributionManagement` section:
+
+```xml
+<snapshotRepository>
+  <id>daisy-nexus-snapshots</id>
+  <name>DAISY Nexus Snapshots</name>
+  <url>http://localhost:8081/nexus/content/repositories/snapshots/</url>
+</snapshotRepository>
+```
+
+and add the following to your `servers` section in `~/.m2/settings.xml`:
+
+```xml
+<server>
+  <id>daisy-nexus-snapshots</id>
+  <username>deployment</username>
+  <password>deployment123</password>
+</server>
+```
+
+For downloading from the repository, add the following to your `repositories` section:
+
+```xml
+<repository>
+  <id>daisy-nexus-snapshots</id>
+  <name>DAISY Nexus Snapshots</name>
+  <url>http://localhost:8081/nexus/content/repositories/snapshots/</url>
+  <releases>
+    <enabled>false</enabled>
+  </releases>
+  <snapshots>
+    <enabled>true</enabled>
+  </snapshots>
+</repository>
+```
+
+Nexus can be configured through the web interface:
+http://localhost:8081/nexus. The login is `admin` and the password is
+`admin123`.

--- a/reprepro/ARTIFACTS
+++ b/reprepro/ARTIFACTS
@@ -1,0 +1,1 @@
+org.daisy.pipeline:assembly

--- a/reprepro/Dockerfile
+++ b/reprepro/Dockerfile
@@ -1,0 +1,18 @@
+FROM        ubuntu:trusty
+RUN         apt-get update
+RUN         apt-get install -y reprepro apache2 maven xsltproc wget
+ADD         repo.daisy.org.conf /etc/apache2/sites-available/repo.daisy.org.conf
+ADD         index.html /var/packages/index.html
+RUN         a2dissite 000-default
+RUN         a2ensite repo.daisy.org
+ADD         distributions /var/packages/debian/conf/distributions
+ADD         REPOSITORIES /var/packages/debian/conf/REPOSITORIES
+ADD         ARTIFACTS /var/packages/debian/conf/ARTIFACTS
+ADD         maven-metadata-to-versions.xsl /bin/maven-metadata-to-versions.xsl
+ADD         update-repository.sh /bin/update-repository.sh
+ADD         crons.conf /tmp/crons.conf
+RUN         chmod +x /bin/update-repository.sh
+RUN         crontab /tmp/crons.conf
+RUN         touch /var/log/update-repository.log
+EXPOSE      80
+ENTRYPOINT  ["/bin/bash", "-c", "service apache2 start && cron && tail -f /var/log/update-repository.log"]

--- a/reprepro/README.md
+++ b/reprepro/README.md
@@ -1,0 +1,22 @@
+# Reprepro Debian Repository
+
+## Running the service
+
+    docker build -t daisy/reprepro .
+    docker run -d -p 80:80 --name reprepro --link nexus:nexus daisy/reprepro
+
+If docker is not available, use the boot2docker image:
+
+    cd ../boot2docker
+    vagrant up
+    vagrant ssh
+
+    $ docker build -t daisy/reprepro ~/pipeline-it/reprepro
+    $ docker run -d -p 80:80 --name reprepro --link nexus:nexus daisy/reprepro
+
+# Using the service
+
+    echo "deb     http://localhost/debian testing main contrib non-free
+    deb-src http://localhost/debian testing main contrib non-free
+    " > /etc/apt/sources.list.d/repo.daisy.org.list
+    sudo aptitude update

--- a/reprepro/REPOSITORIES
+++ b/reprepro/REPOSITORIES
@@ -1,0 +1,1 @@
+http://nexus:8081/nexus/content/repositories/snapshots/

--- a/reprepro/crons.conf
+++ b/reprepro/crons.conf
@@ -1,0 +1,1 @@
+*/15 * * * * /bin/update-repository.sh >> /var/log/update-repository.log 2>&1

--- a/reprepro/distributions
+++ b/reprepro/distributions
@@ -1,0 +1,7 @@
+Origin: Your Name
+Label: Your label
+Suite: testing
+Codename: testing
+Architectures: amd64 i386 source
+Components: main contrib non-free
+Description: Your description

--- a/reprepro/index.html
+++ b/reprepro/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>repo.daisy.org</title>
+  </head>
+  <body>
+    <h1>repo.daisy.org</h1>
+  </body>
+</html>

--- a/reprepro/maven-metadata-to-versions.xsl
+++ b/reprepro/maven-metadata-to-versions.xsl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+    
+    <xsl:output method="text"/>
+    
+    <xsl:template match="/*">
+        <xsl:for-each select="/metadata/versioning/versions/version">
+            <xsl:value-of select="normalize-space(.)"/>
+            <xsl:text>
+            </xsl:text>
+        </xsl:for-each>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/reprepro/repo.daisy.org.conf
+++ b/reprepro/repo.daisy.org.conf
@@ -1,0 +1,30 @@
+<Directory /var/packages>
+  Options Indexes FollowSymLinks
+  AllowOverride None
+  Require all granted
+</Directory>
+<VirtualHost *>
+  DocumentRoot /var/packages
+  ServerName repo.daisy.org
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  LogLevel warn
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+  ServerSignature On
+  <Directory "/var/packages">
+     Options Indexes FollowSymLinks MultiViews
+     DirectoryIndex index.html
+     AllowOverride Options
+     Order allow,deny
+     allow from all
+  </Directory>
+  <Directory "/var/packages/*/conf">
+    Order allow,deny
+    Deny from all
+    Satisfy all
+  </Directory>
+  <Directory "/var/packages/*/db">
+    Order allow,deny
+    Deny from all
+    Satisfy all
+  </Directory>
+</VirtualHost>

--- a/reprepro/update-repository.sh
+++ b/reprepro/update-repository.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# DEPENDENCY: xsltproc (easy to install; alternatively modify to use another XSLT processor)
+
+set -e
+
+cd /var/packages/debian/conf
+
+if [ ! -f REPOSITORIES ]; then
+    echo "Please add the URL to at least one repository to the file 'REPOSITORIES' (one repository on each line)'"
+    exit
+fi
+
+if [ ! -f ARTIFACTS ]; then
+    echo "Please add coordinates to at least one artifact (groupId:artifactId) to the file 'ARTIFACTS' (one artifact on each line)'"
+    exit
+fi
+
+if [ "`which xsltproc | grep -v \"not found\" | wc -l`" = "0" ]; then
+    echo "xsltproc is required; please install xsltproc"
+    exit
+fi
+
+if [ "`which mvn | grep -v \"not found\" | wc -l`" = "0" ]; then
+    echo "mvn is required; please install mvn"
+    exit
+fi
+
+function get {
+    # $1 = https://oss.sonatype.org/content/repositories/snapshots
+    # $2 = org.daisy.pipeline:assembly
+    # $3 = 1.8.1-SNAPSHOT
+    mvn org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=$1 -Dartifact=$2:$3:deb:all -Ddest=/tmp/temp.deb -Dtransitive=false
+}
+ 
+function versions {
+    # $1 = https://oss.sonatype.org/content/repositories/snapshots
+    # $2 = org.daisy.pipeline:assembly
+    wget -O - $1/`echo $2  | sed 's/[\.:]/\//g'`/maven-metadata.xml 2> /dev/null | xsltproc /bin/maven-metadata-to-versions.xsl -
+}
+
+cat REPOSITORIES | while read repository; do
+    if [ "$repository" = "" ]; then continue; fi
+    echo "Repository: $repository"
+    cat ARTIFACTS | while read artifact; do
+        if [ "$artifact" = "" ]; then continue; fi
+        echo "Artifact: $artifact"
+        versions $repository $artifact | while read -r version; do
+            if [ "$version" = "" ]; then continue; fi
+            if [ "`cat PUBLISHED | grep $artifact:$version | wc -l`" = "0" ] ; then
+                echo "getting $artifact:$version"
+                get $repository $artifact $version
+                if [ -f /tmp/temp.deb ]; then
+                    if [ "`which reprepro | grep -v \"not found\" | wc -l`" -gt "0" ]; then # skip if reprepro not installed (for testing)
+                        if reprepro -b /var/packages/debian -S contrib -P optional includedeb testing /tmp/temp.deb ; then
+                            echo "$artifact:$version" >> PUBLISHED
+                        fi
+                    fi
+                    rm /tmp/temp.deb
+                else
+                    echo "$artifact:$version does not contain a deb; marking as PUBLISHED to avoid future checks"
+                    echo "$artifact:$version" >> PUBLISHED
+                fi
+            else
+                echo "already published, skipping: $artifact:$version"
+            fi
+        done
+    done
+done


### PR DESCRIPTION
Nexus is a Maven repository and Reprepro is a Debian repository.

The purpose is twofold:
1. to demonstrate/document how to setup these services and to test them, and
2. to be able to use the services for making artifacts/packages
   available to tests inside a guest box.

A possible advantage of the latter is that untested artifacts/packages
don't necessarily have to be build locally in the test box, or deployed
to a public repository.
